### PR TITLE
Fix build script exit handling and packaging info

### DIFF
--- a/cmd/nebius-observability-agent-updater/main.go
+++ b/cmd/nebius-observability-agent-updater/main.go
@@ -18,6 +18,11 @@ import (
 )
 
 func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	exitCode := 0
 	configPath := flag.String("config", "", "path to config file")
 	flag.Parse()
 	var cfg *config.Config
@@ -37,8 +42,7 @@ func main() {
 	cli, err := client.New(metadataReader, oh, dh, cfg, logger, metadataReader.GetIamToken)
 	if err != nil {
 		logger.Error("failed to create client", "error", err)
-		defer syscall.Exit(1)
-		return
+		return 1
 	}
 	agentsList := []agents.AgentData{agents.NewO11yagent()}
 	app := application.New(cfg, cli, logger, agentsList, oh)
@@ -54,7 +58,6 @@ func main() {
 		errChan <- app.Run(ctx)
 	}()
 
-	exitCode := 0
 	select {
 	case err := <-errChan:
 		if err != nil {
@@ -74,5 +77,5 @@ func main() {
 			logger.Info("App shut down gracefully")
 		}
 	}
-	defer os.Exit(exitCode)
+	return exitCode
 }

--- a/debian/DEBIAN/control
+++ b/debian/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: nebius-observability-agent-updater
 Name: Nebius Observability Agent Updater
 Description: Service to update the Nebius Observability Agent
-Author:: Nebius <support@nebius.ai>
+Author: Nebius <support@nebius.ai>
 Maintainer: Nebius <support@nebius.ai>

--- a/scripts/build_deb.sh
+++ b/scripts/build_deb.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 set -x
 DEB_BUILD_DIR=/tmp/nebius-observability-agent-updater
 


### PR DESCRIPTION
## Summary
- exit gracefully by returning status codes
- enforce stricter shell options in `build_deb.sh`
- fix author field typo in Debian control file

## Testing
- `golangci-lint run -c .golangci.yaml`
- `go vet ./...`
- `staticcheck ./...`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683f5db4b90083328af14a91fcfb12fb