### PR TITLE
Prevent hang on unresponsive /mnt/cloud-metadata mount

### DIFF
--- a/internal/application/application_test.go
+++ b/internal/application/application_test.go
@@ -18,6 +18,13 @@ import (
 	"go.uber.org/goleak"
 )
 
+const (
+	logMsgPolling = "Polling for "
+	testVersion   = "1.0.1"
+	flagKey       = "FLAG"
+	flagValTrue   = "true"
+)
+
 type MockUpdaterClient struct {
 	mock.Mock
 }
@@ -138,21 +145,21 @@ func TestApp_poll(t *testing.T) {
 				agent.On("GetServiceName").Return("test-agent")
 				agent.On("GetEnvironmentFilePath").Return("")
 			},
-			expectedLogMsg: "Polling for ",
+			expectedLogMsg: logMsgPolling,
 		},
 		{
 			name: "Successful poll with update",
 			setupMocks: func(client *MockUpdaterClient, agent *MockAgentData, oh *MockOSHelper) {
 				client.On("SendAgentData", mock.Anything).Return(&agentmanager.GetVersionResponse{
 					Action:   agentmanager.Action_UPDATE,
-					Response: &agentmanager.GetVersionResponse_Update{Update: &agentmanager.UpdateActionParams{Version: "1.0.1"}},
+					Response: &agentmanager.GetVersionResponse_Update{Update: &agentmanager.UpdateActionParams{Version: testVersion}},
 				}, nil)
 				agent.On("GetServiceName").Return("test-agent")
 				agent.On("GetEnvironmentFilePath").Return("")
 				oh.On("GetSystemUptime").Return(20*time.Minute, nil)
-				agent.On("Update", mock.Anything, "1.0.1").Return(nil)
+				agent.On("Update", mock.Anything, testVersion).Return(nil)
 			},
-			expectedLogMsg: "Polling for ",
+			expectedLogMsg: logMsgPolling,
 		},
 		{
 			name: "Successful poll with restart",
@@ -164,7 +171,7 @@ func TestApp_poll(t *testing.T) {
 				agent.On("GetEnvironmentFilePath").Return("")
 				agent.On("Restart").Return(nil)
 			},
-			expectedLogMsg: "Polling for ",
+			expectedLogMsg: logMsgPolling,
 		},
 		{
 			name: "Failed to send agent data",
@@ -206,11 +213,11 @@ func TestApp_Update(t *testing.T) {
 			setupMocks: func(agent *MockAgentData, oh *MockOSHelper) {
 				oh.On("GetSystemUptime").Return(20*time.Minute, nil)
 				agent.On("GetServiceName").Return("test-agent")
-				agent.On("Update", mock.Anything, "1.0.1").Return(nil)
+				agent.On("Update", mock.Anything, testVersion).Return(nil)
 			},
 			response: &agentmanager.GetVersionResponse{
 				Action:   agentmanager.Action_UPDATE,
-				Response: &agentmanager.GetVersionResponse_Update{Update: &agentmanager.UpdateActionParams{Version: "1.0.1"}},
+				Response: &agentmanager.GetVersionResponse_Update{Update: &agentmanager.UpdateActionParams{Version: testVersion}},
 			},
 			shouldUpdate: true,
 		},
@@ -221,7 +228,7 @@ func TestApp_Update(t *testing.T) {
 			},
 			response: &agentmanager.GetVersionResponse{
 				Action:   agentmanager.Action_UPDATE,
-				Response: &agentmanager.GetVersionResponse_Update{Update: &agentmanager.UpdateActionParams{Version: "1.0.1"}},
+				Response: &agentmanager.GetVersionResponse_Update{Update: &agentmanager.UpdateActionParams{Version: testVersion}},
 			},
 			shouldUpdate: false,
 		},
@@ -230,11 +237,11 @@ func TestApp_Update(t *testing.T) {
 			setupMocks: func(agent *MockAgentData, oh *MockOSHelper) {
 				oh.On("GetSystemUptime").Return(time.Duration(0), errors.New("uptime error"))
 				agent.On("GetServiceName").Return("test-agent")
-				agent.On("Update", mock.Anything, "1.0.1").Return(nil)
+				agent.On("Update", mock.Anything, testVersion).Return(nil)
 			},
 			response: &agentmanager.GetVersionResponse{
 				Action:   agentmanager.Action_UPDATE,
-				Response: &agentmanager.GetVersionResponse_Update{Update: &agentmanager.UpdateActionParams{Version: "1.0.1"}},
+				Response: &agentmanager.GetVersionResponse_Update{Update: &agentmanager.UpdateActionParams{Version: testVersion}},
 			},
 			shouldUpdate: true,
 		},
@@ -358,7 +365,7 @@ func TestGenerateEnvironmentFileContent(t *testing.T) {
 		},
 		{
 			name:  "single flag",
-			flags: map[string]string{"FEATURE_FLAG_GPU_LOGS_COLLECTION_ENABLED": "true"},
+			flags: map[string]string{"FEATURE_FLAG_GPU_LOGS_COLLECTION_ENABLED": flagValTrue},
 			expected: header +
 				"FEATURE_FLAG_GPU_LOGS_COLLECTION_ENABLED=true\n",
 		},
@@ -366,7 +373,7 @@ func TestGenerateEnvironmentFileContent(t *testing.T) {
 			name: "multiple flags sorted",
 			flags: map[string]string{
 				"FEATURE_FLAG_Z_LAST":  "false",
-				"FEATURE_FLAG_A_FIRST": "true",
+				"FEATURE_FLAG_A_FIRST": flagValTrue,
 			},
 			expected: header +
 				"FEATURE_FLAG_A_FIRST=true\n" +
@@ -374,31 +381,31 @@ func TestGenerateEnvironmentFileContent(t *testing.T) {
 		},
 		{
 			name:  "value with spaces is quoted",
-			flags: map[string]string{"FLAG": "hello world"},
+			flags: map[string]string{flagKey: "hello world"},
 			expected: header +
 				"FLAG=\"hello world\"\n",
 		},
 		{
 			name:  "value with double quote is escaped",
-			flags: map[string]string{"FLAG": `say "hi"`},
+			flags: map[string]string{flagKey: `say "hi"`},
 			expected: header +
 				`FLAG="say \"hi\""` + "\n",
 		},
 		{
 			name:  "value with backslash is escaped",
-			flags: map[string]string{"FLAG": `a\b`},
+			flags: map[string]string{flagKey: `a\b`},
 			expected: header +
 				`FLAG="a\\b"` + "\n",
 		},
 		{
 			name:  "value with leading whitespace is quoted",
-			flags: map[string]string{"FLAG": " leading"},
+			flags: map[string]string{flagKey: " leading"},
 			expected: header +
 				"FLAG=\" leading\"\n",
 		},
 		{
 			name:     "simple value not quoted",
-			flags:    map[string]string{"FLAG": "simple"},
+			flags:    map[string]string{flagKey: "simple"},
 			expected: header + "FLAG=simple\n",
 		},
 	}
@@ -421,7 +428,7 @@ func TestApp_processFeatureFlags(t *testing.T) {
 
 		app := newTestApp(nil, oh)
 		restarted := app.processFeatureFlags(&agentmanager.GetVersionResponse{
-			FeatureFlags: map[string]string{"FLAG": "true"},
+			FeatureFlags: map[string]string{flagKey: flagValTrue},
 		}, agent)
 
 		assert.False(t, restarted)
@@ -459,7 +466,7 @@ func TestApp_processFeatureFlags(t *testing.T) {
 
 		app := newTestApp(nil, oh)
 		restarted := app.processFeatureFlags(&agentmanager.GetVersionResponse{
-			FeatureFlags: map[string]string{"FEATURE_FLAG_GPU_LOGS_COLLECTION_ENABLED": "true"},
+			FeatureFlags: map[string]string{"FEATURE_FLAG_GPU_LOGS_COLLECTION_ENABLED": flagValTrue},
 		}, agent)
 
 		assert.True(t, restarted)
@@ -482,7 +489,7 @@ func TestApp_processFeatureFlags(t *testing.T) {
 
 		app := newTestApp(nil, oh)
 		restarted := app.processFeatureFlags(&agentmanager.GetVersionResponse{
-			FeatureFlags: map[string]string{"FLAG": "true"},
+			FeatureFlags: map[string]string{flagKey: flagValTrue},
 		}, agent)
 
 		assert.False(t, restarted)
@@ -507,7 +514,7 @@ func TestApp_processFeatureFlags(t *testing.T) {
 
 		app := newTestApp(nil, oh)
 		restarted := app.processFeatureFlags(&agentmanager.GetVersionResponse{
-			FeatureFlags: map[string]string{"FLAG": "true"},
+			FeatureFlags: map[string]string{flagKey: flagValTrue},
 		}, agent)
 
 		assert.False(t, restarted)
@@ -529,7 +536,7 @@ func TestApp_processFeatureFlags(t *testing.T) {
 
 		app := newTestApp(nil, oh)
 		restarted := app.processFeatureFlags(&agentmanager.GetVersionResponse{
-			FeatureFlags: map[string]string{"FLAG": "true"},
+			FeatureFlags: map[string]string{flagKey: flagValTrue},
 		}, agent)
 
 		assert.False(t, restarted)
@@ -550,7 +557,7 @@ func TestApp_processFeatureFlags(t *testing.T) {
 
 		app := newTestApp(nil, oh)
 		restarted := app.processFeatureFlags(&agentmanager.GetVersionResponse{
-			FeatureFlags: map[string]string{"FLAG": "true"},
+			FeatureFlags: map[string]string{flagKey: flagValTrue},
 		}, agent)
 
 		assert.True(t, restarted)
@@ -576,7 +583,7 @@ func TestApp_processFeatureFlags(t *testing.T) {
 
 		app := newTestApp(nil, oh)
 		restarted := app.processFeatureFlags(&agentmanager.GetVersionResponse{
-			FeatureFlags: map[string]string{"FLAG": "true"},
+			FeatureFlags: map[string]string{flagKey: flagValTrue},
 		}, agent)
 
 		assert.True(t, restarted)
@@ -635,7 +642,7 @@ func TestApp_processFeatureFlags(t *testing.T) {
 
 		app := newTestApp(nil, oh)
 		restarted := app.processFeatureFlags(&agentmanager.GetVersionResponse{
-			FeatureFlags: map[string]string{"FLAG": "true"},
+			FeatureFlags: map[string]string{flagKey: flagValTrue},
 		}, agent)
 
 		assert.False(t, restarted)
@@ -662,7 +669,7 @@ func TestApp_processFeatureFlags(t *testing.T) {
 
 		app := newTestApp(nil, oh)
 		restarted := app.processFeatureFlags(&agentmanager.GetVersionResponse{
-			FeatureFlags: map[string]string{"FLAG": "new"},
+			FeatureFlags: map[string]string{flagKey: "new"},
 		}, agent)
 
 		assert.True(t, restarted)
@@ -687,7 +694,7 @@ func TestApp_processFeatureFlags(t *testing.T) {
 
 		app := newTestApp(nil, oh)
 		restarted := app.processFeatureFlags(&agentmanager.GetVersionResponse{
-			FeatureFlags: map[string]string{"FLAG": "true"},
+			FeatureFlags: map[string]string{flagKey: flagValTrue},
 		}, agent)
 
 		assert.False(t, restarted)
@@ -772,32 +779,32 @@ func TestApp_validateFeatureFlags(t *testing.T) {
 		},
 		{
 			name:     "valid keys",
-			input:    map[string]string{"FEATURE_FLAG": "true", "_PRIVATE": "1", "a": "b"},
-			expected: map[string]string{"FEATURE_FLAG": "true", "_PRIVATE": "1", "a": "b"},
+			input:    map[string]string{"FEATURE_FLAG": flagValTrue, "_PRIVATE": "1", "a": "b"},
+			expected: map[string]string{"FEATURE_FLAG": flagValTrue, "_PRIVATE": "1", "a": "b"},
 		},
 		{
 			name:     "invalid key with space",
-			input:    map[string]string{"BAD KEY": "true", "GOOD_KEY": "val"},
+			input:    map[string]string{"BAD KEY": flagValTrue, "GOOD_KEY": "val"},
 			expected: map[string]string{"GOOD_KEY": "val"},
 		},
 		{
 			name:     "invalid key starting with digit",
-			input:    map[string]string{"1BAD": "true"},
+			input:    map[string]string{"1BAD": flagValTrue},
 			expected: map[string]string{},
 		},
 		{
 			name:     "invalid key with special chars",
-			input:    map[string]string{"BAD-KEY": "true", "BAD.KEY": "false"},
+			input:    map[string]string{"BAD-KEY": flagValTrue, "BAD.KEY": "false"},
 			expected: map[string]string{},
 		},
 		{
 			name:     "newline in value",
-			input:    map[string]string{"FLAG": "line1\nline2"},
+			input:    map[string]string{flagKey: "line1\nline2"},
 			expected: map[string]string{},
 		},
 		{
 			name:     "carriage return in value",
-			input:    map[string]string{"FLAG": "line1\rline2"},
+			input:    map[string]string{flagKey: "line1\rline2"},
 			expected: map[string]string{},
 		},
 		{
@@ -823,7 +830,7 @@ func TestApp_poll_restart_with_feature_flag_change(t *testing.T) {
 
 	client.On("SendAgentData", mock.Anything).Return(&agentmanager.GetVersionResponse{
 		Action:       agentmanager.Action_RESTART,
-		FeatureFlags: map[string]string{"NEW_FLAG": "true"},
+		FeatureFlags: map[string]string{"NEW_FLAG": flagValTrue},
 	}, nil)
 	agent.On("GetServiceName").Return("test-agent")
 	agent.On("GetEnvironmentFilePath").Return(envPath)

--- a/internal/healthcheck/healthcheck.go
+++ b/internal/healthcheck/healthcheck.go
@@ -9,6 +9,11 @@ import (
 	"time"
 )
 
+const (
+	statusError   = "error"
+	moduleProcess = "process"
+)
+
 type Response struct {
 	StatusMsg     string                 `json:"status"`
 	UpSince       time.Time              `json:"upSince"`
@@ -30,10 +35,10 @@ type Parameter struct {
 
 func makeErrorResponse(message string) Response {
 	return Response{
-		StatusMsg: "error",
+		StatusMsg: statusError,
 		Reasons:   []string{message},
 		CheckStatuses: map[string]CheckStatus{
-			"process": {
+			moduleProcess: {
 				IsOk:    false,
 				Reasons: []string{message},
 			},

--- a/internal/healthcheck/healthcheck_test.go
+++ b/internal/healthcheck/healthcheck_test.go
@@ -9,6 +9,15 @@ import (
 	"time"
 )
 
+const (
+	moduleCPU       = "cpu"
+	moduleGPU       = "gpu"
+	reasonProcessOk = "Process running normally"
+	reasonCPUOk     = "CPU pipeline operational"
+	reasonDBError   = "Database connection error"
+	reasonHighCPU   = "High CPU usage"
+)
+
 // nolint: gocognit
 func TestCheckHealthWithReasons(t *testing.T) {
 	tests := []struct {
@@ -26,15 +35,15 @@ func TestCheckHealthWithReasons(t *testing.T) {
 				Uptime:    "1h",
 				Reasons:   []string{"All systems operational"},
 				CheckStatuses: map[string]CheckStatus{
-					"process": {
+					moduleProcess: {
 						IsOk:    true,
-						Reasons: []string{"Process running normally"},
+						Reasons: []string{reasonProcessOk},
 					},
-					"cpu": {
+					moduleCPU: {
 						IsOk:    true,
-						Reasons: []string{"CPU pipeline operational"},
+						Reasons: []string{reasonCPUOk},
 					},
-					"gpu": {
+					moduleGPU: {
 						IsOk:    true,
 						Reasons: []string{"GPU pipeline operational"},
 					},
@@ -46,15 +55,15 @@ func TestCheckHealthWithReasons(t *testing.T) {
 				StatusMsg: "healthy",
 				Reasons:   []string{"All systems operational"},
 				CheckStatuses: map[string]CheckStatus{
-					"process": {
+					moduleProcess: {
 						IsOk:    true,
-						Reasons: []string{"Process running normally"},
+						Reasons: []string{reasonProcessOk},
 					},
-					"cpu": {
+					moduleCPU: {
 						IsOk:    true,
-						Reasons: []string{"CPU pipeline operational"},
+						Reasons: []string{reasonCPUOk},
 					},
-					"gpu": {
+					moduleGPU: {
 						IsOk:    true,
 						Reasons: []string{"GPU pipeline operational"},
 					},
@@ -64,20 +73,20 @@ func TestCheckHealthWithReasons(t *testing.T) {
 		{
 			name: "Mixed health status with some modules failing",
 			serverResponse: Response{
-				StatusMsg: "error",
+				StatusMsg: statusError,
 				UpSince:   time.Now(),
 				Uptime:    "1h",
 				Reasons:   []string{"GPU pipeline error"},
 				CheckStatuses: map[string]CheckStatus{
-					"process": {
+					moduleProcess: {
 						IsOk:    true,
-						Reasons: []string{"Process running normally"},
+						Reasons: []string{reasonProcessOk},
 					},
-					"cpu": {
+					moduleCPU: {
 						IsOk:    true,
-						Reasons: []string{"CPU pipeline operational"},
+						Reasons: []string{reasonCPUOk},
 					},
-					"gpu": {
+					moduleGPU: {
 						IsOk:    false,
 						Reasons: []string{"GPU pipeline error: CUDA initialization failed"},
 					},
@@ -86,18 +95,18 @@ func TestCheckHealthWithReasons(t *testing.T) {
 			statusCode:  http.StatusInternalServerError,
 			wantHealthy: false,
 			wantResponse: Response{
-				StatusMsg: "error",
+				StatusMsg: statusError,
 				Reasons:   []string{"GPU pipeline error"},
 				CheckStatuses: map[string]CheckStatus{
-					"process": {
+					moduleProcess: {
 						IsOk:    true,
-						Reasons: []string{"Process running normally"},
+						Reasons: []string{reasonProcessOk},
 					},
-					"cpu": {
+					moduleCPU: {
 						IsOk:    true,
-						Reasons: []string{"CPU pipeline operational"},
+						Reasons: []string{reasonCPUOk},
 					},
-					"gpu": {
+					moduleGPU: {
 						IsOk:    false,
 						Reasons: []string{"GPU pipeline error: CUDA initialization failed"},
 					},
@@ -107,26 +116,26 @@ func TestCheckHealthWithReasons(t *testing.T) {
 		{
 			name: "All modules unhealthy",
 			serverResponse: Response{
-				StatusMsg: "error",
+				StatusMsg: statusError,
 				UpSince:   time.Now(),
 				Uptime:    "1h",
-				Reasons:   []string{"Database connection error", "High CPU usage"},
+				Reasons:   []string{reasonDBError, reasonHighCPU},
 				CheckStatuses: map[string]CheckStatus{
-					"process": {
+					moduleProcess: {
 						IsOk:    false,
-						Reasons: []string{"Database connection error", "High CPU usage"},
+						Reasons: []string{reasonDBError, reasonHighCPU},
 					},
 				},
 			},
 			statusCode:  http.StatusInternalServerError,
 			wantHealthy: false,
 			wantResponse: Response{
-				StatusMsg: "error",
-				Reasons:   []string{"Database connection error", "High CPU usage"},
+				StatusMsg: statusError,
+				Reasons:   []string{reasonDBError, reasonHighCPU},
 				CheckStatuses: map[string]CheckStatus{
-					"process": {
+					moduleProcess: {
 						IsOk:    false,
-						Reasons: []string{"Database connection error", "High CPU usage"},
+						Reasons: []string{reasonDBError, reasonHighCPU},
 					},
 				},
 			},
@@ -267,11 +276,11 @@ func TestCheckHealthWithReasons_ServerErrors(t *testing.T) {
 			}
 
 			// Verify error response structure
-			if resp.StatusMsg != "error" {
+			if resp.StatusMsg != statusError {
 				t.Errorf("CheckHealthWithReasons() status = %v, want 'error'", resp.StatusMsg)
 			}
 
-			if len(resp.CheckStatuses) != 1 || resp.CheckStatuses["process"].IsOk {
+			if len(resp.CheckStatuses) != 1 || resp.CheckStatuses[moduleProcess].IsOk {
 				t.Errorf("CheckHealthWithReasons() invalid error response structure")
 			}
 		})

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -35,6 +36,17 @@ const instanceDataCacheTTL = 5 * time.Minute
 // tokenRefreshMargin is how long before expiry we refresh the token
 const tokenRefreshMargin = 1 * time.Hour
 
+// maxPendingFileReads is the cap on leaked file-read goroutines. Once exceeded,
+// the process panics so systemd can restart it (Restart=always in the unit
+// file); the assumption is the mount is wedged and only a fresh process after
+// a remount will recover.
+const maxPendingFileReads = 100
+
+// fileReadTimeout bounds os.ReadFile calls so a hung mount (e.g. unresponsive
+// /mnt/cloud-metadata) cannot block the poll loop indefinitely. Declared as
+// var so tests can shorten it.
+var fileReadTimeout = 5 * time.Second
+
 type cachedToken struct {
 	token     string
 	expiresAt time.Time
@@ -51,6 +63,8 @@ type Reader struct {
 
 	tokenMu   sync.Mutex
 	cachedIAM *cachedToken
+
+	pendingFileReads atomic.Int64
 }
 
 func NewReader(cfg Config, logger *slog.Logger) *Reader {
@@ -73,20 +87,24 @@ func (r *Reader) GetParentId() (string, error) {
 }
 
 func (r *Reader) GetInstanceId() (instanceId string, isFallback bool, err error) {
-	instanceId, err = r.readAndTrimFile(r.cfg.Path + "/" + r.cfg.InstanceIdFilename)
-	if err == nil {
-		return instanceId, false, nil
-	}
-	r.logger.Warn("Failed to get instance_id from file, falling back to IMDS", "error", err)
-
 	if r.cfg.UseMetadataService {
 		data, imdsErr := r.getInstanceData()
 		if imdsErr == nil {
-			return data.ID, true, nil
+			return data.ID, false, nil
 		}
-		return "", true, fmt.Errorf("failed to get instance_id from file: %w and from IMDS: %w", err, imdsErr)
+		r.logger.Warn("Failed to get instance_id from IMDS, falling back to file", "error", imdsErr)
+		instanceId, fileErr := r.readAndTrimFile(r.cfg.Path + "/" + r.cfg.InstanceIdFilename)
+		if fileErr != nil {
+			return "", true, fmt.Errorf("failed to get instance_id from IMDS: %w and from file: %w", imdsErr, fileErr)
+		}
+		return instanceId, true, nil
 	}
-	return "", false, err
+
+	instanceId, err = r.readAndTrimFile(r.cfg.Path + "/" + r.cfg.InstanceIdFilename)
+	if err != nil {
+		return "", false, err
+	}
+	return instanceId, false, nil
 }
 
 func (r *Reader) GetIamToken() (string, error) {
@@ -221,11 +239,39 @@ func (r *Reader) doMetadataRequest(url string) ([]byte, error) {
 	return body, nil
 }
 
+// readAndTrimFile reads filename with a hard timeout so a hung mount cannot
+// block the caller. The underlying goroutine may leak until the syscall
+// eventually unblocks (or forever, if the mount never recovers); leaked
+// goroutines are counted, and if the cap is exceeded the process exits so
+// systemd can restart it on a (hopefully) recovered mount.
 func (r *Reader) readAndTrimFile(filename string) (string, error) {
 	r.logger.Debug("Reading file", "filename", filename)
-	content, err := os.ReadFile(filename)
-	if err != nil {
-		return "", err
+
+	inflight := r.pendingFileReads.Add(1)
+	if inflight > maxPendingFileReads {
+		r.logger.Error("too many leaked file-read goroutines, panicking for restart",
+			"pending", inflight, "threshold", maxPendingFileReads, "filename", filename)
+		panic(fmt.Sprintf("metadata: %d leaked file-read goroutines exceed cap %d (filename=%s)",
+			inflight, maxPendingFileReads, filename))
 	}
-	return strings.TrimSpace(string(content)), nil
+
+	type result struct {
+		content []byte
+		err     error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		defer r.pendingFileReads.Add(-1)
+		content, err := os.ReadFile(filename)
+		ch <- result{content: content, err: err}
+	}()
+	select {
+	case res := <-ch:
+		if res.err != nil {
+			return "", res.err
+		}
+		return strings.TrimSpace(string(res.content)), nil
+	case <-time.After(fileReadTimeout):
+		return "", fmt.Errorf("timeout reading %s after %s", filename, fileReadTimeout)
+	}
 }

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -21,6 +21,10 @@ const (
 	instanceDataPath   = "/v1/instance-data"
 	tokenAccessPath    = "/v1/iam/tsa/token/access_token"
 	tokenExpiresAtPath = "/v1/iam/tsa/token/expires_at"
+
+	instanceIDFile = "instance-id"
+	unreachableURL = "http://127.0.0.1:1"
+	tsaTokenType   = "tsa"
 )
 
 func testLogger() *slog.Logger {
@@ -62,7 +66,7 @@ func TestGetInstanceId_FromIMDS(t *testing.T) {
 	defer server.Close()
 
 	tmpDir := t.TempDir()
-	err := os.WriteFile(filepath.Join(tmpDir, "instance-id"), []byte("inst-from-file\n"), 0644)
+	err := os.WriteFile(filepath.Join(tmpDir, instanceIDFile), []byte("inst-from-file\n"), 0644)
 	require.NoError(t, err)
 
 	reader := NewReader(Config{
@@ -70,7 +74,7 @@ func TestGetInstanceId_FromIMDS(t *testing.T) {
 		MetadataServiceURL:         server.URL,
 		MetadataServiceFallbackURL: server.URL,
 		Path:                       tmpDir,
-		InstanceIdFilename:         "instance-id",
+		InstanceIdFilename:         instanceIDFile,
 	}, testLogger())
 
 	// IMDS is primary when UseMetadataService is true; the file must not be touched.
@@ -82,15 +86,15 @@ func TestGetInstanceId_FromIMDS(t *testing.T) {
 
 func TestGetInstanceId_FileFallback_WhenIMDSFails(t *testing.T) {
 	tmpDir := t.TempDir()
-	err := os.WriteFile(filepath.Join(tmpDir, "instance-id"), []byte("inst-from-file\n"), 0644)
+	err := os.WriteFile(filepath.Join(tmpDir, instanceIDFile), []byte("inst-from-file\n"), 0644)
 	require.NoError(t, err)
 
 	reader := NewReader(Config{
 		UseMetadataService:         true,
-		MetadataServiceURL:         "http://127.0.0.1:1",
-		MetadataServiceFallbackURL: "http://127.0.0.1:1",
+		MetadataServiceURL:         unreachableURL,
+		MetadataServiceFallbackURL: unreachableURL,
 		Path:                       tmpDir,
-		InstanceIdFilename:         "instance-id",
+		InstanceIdFilename:         instanceIDFile,
 	}, testLogger())
 
 	instanceId, isFallback, err := reader.GetInstanceId()
@@ -113,10 +117,10 @@ func TestGetInstanceId_IMDSFallbackURL(t *testing.T) {
 	// Primary IMDS unreachable — uses fallback URL; still treated as IMDS, not a file fallback.
 	reader := NewReader(Config{
 		UseMetadataService:         true,
-		MetadataServiceURL:         "http://127.0.0.1:1",
+		MetadataServiceURL:         unreachableURL,
 		MetadataServiceFallbackURL: fallbackServer.URL,
 		Path:                       t.TempDir(),
-		InstanceIdFilename:         "instance-id",
+		InstanceIdFilename:         instanceIDFile,
 	}, testLogger())
 
 	instanceId, isFallback, err := reader.GetInstanceId()
@@ -146,7 +150,7 @@ func TestGetIamToken_IMDS(t *testing.T) {
 		UseMetadataService:         true,
 		MetadataServiceURL:         server.URL,
 		MetadataServiceFallbackURL: server.URL,
-		MetadataTokenType:          "tsa",
+		MetadataTokenType:          tsaTokenType,
 	}, testLogger())
 
 	token, err := reader.GetIamToken()
@@ -176,7 +180,7 @@ func TestGetIamToken_Cached(t *testing.T) {
 		UseMetadataService:         true,
 		MetadataServiceURL:         server.URL,
 		MetadataServiceFallbackURL: server.URL,
-		MetadataTokenType:          "tsa",
+		MetadataTokenType:          tsaTokenType,
 	}, testLogger())
 
 	// First call fetches from IMDS
@@ -214,7 +218,7 @@ func TestGetIamToken_RefreshesWhenNearExpiry(t *testing.T) {
 		UseMetadataService:         true,
 		MetadataServiceURL:         server.URL,
 		MetadataServiceFallbackURL: server.URL,
-		MetadataTokenType:          "tsa",
+		MetadataTokenType:          tsaTokenType,
 	}, testLogger())
 
 	// First fetch
@@ -261,7 +265,7 @@ func TestGetIamToken_UsesStaleTokenOnRefreshFailure(t *testing.T) {
 		UseMetadataService:         true,
 		MetadataServiceURL:         server.URL,
 		MetadataServiceFallbackURL: server.URL,
-		MetadataTokenType:          "tsa",
+		MetadataTokenType:          tsaTokenType,
 	}, testLogger())
 
 	// First fetch succeeds
@@ -304,7 +308,7 @@ func TestGetIamToken_AlreadyExpired(t *testing.T) {
 		UseMetadataService:         true,
 		MetadataServiceURL:         server.URL,
 		MetadataServiceFallbackURL: server.URL,
-		MetadataTokenType:          "tsa",
+		MetadataTokenType:          tsaTokenType,
 		Path:                       tmpDir,
 		IamTokenFilename:           "tsa-token",
 	}, testLogger())
@@ -327,11 +331,11 @@ func TestGetIamToken_FileFallback(t *testing.T) {
 
 	reader := NewReader(Config{
 		UseMetadataService:         true,
-		MetadataServiceURL:         "http://127.0.0.1:1",
-		MetadataServiceFallbackURL: "http://127.0.0.1:1",
+		MetadataServiceURL:         unreachableURL,
+		MetadataServiceFallbackURL: unreachableURL,
 		Path:                       tmpDir,
 		IamTokenFilename:           "tsa-token",
-		MetadataTokenType:          "tsa",
+		MetadataTokenType:          tsaTokenType,
 	}, testLogger())
 
 	token, err := reader.GetIamToken()
@@ -448,13 +452,13 @@ func TestGetInstanceData_StaleCache_OnRefreshFailure(t *testing.T) {
 
 func TestGetInstanceId_MetadataServiceDisabled(t *testing.T) {
 	tmpDir := t.TempDir()
-	err := os.WriteFile(filepath.Join(tmpDir, "instance-id"), []byte("inst-from-file\n"), 0644)
+	err := os.WriteFile(filepath.Join(tmpDir, instanceIDFile), []byte("inst-from-file\n"), 0644)
 	require.NoError(t, err)
 
 	reader := NewReader(Config{
 		UseMetadataService: false,
 		Path:               tmpDir,
-		InstanceIdFilename: "instance-id",
+		InstanceIdFilename: instanceIDFile,
 	}, testLogger())
 
 	instanceId, isFallback, err := reader.GetInstanceId()

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -7,6 +7,9 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -47,24 +50,7 @@ func TestGetParentId_IMDS(t *testing.T) {
 	assert.Equal(t, "parent-456", parentId)
 }
 
-func TestGetInstanceId_FromFile(t *testing.T) {
-	tmpDir := t.TempDir()
-	err := os.WriteFile(filepath.Join(tmpDir, "instance-id"), []byte("inst-from-file\n"), 0644)
-	require.NoError(t, err)
-
-	reader := NewReader(Config{
-		UseMetadataService: true,
-		Path:               tmpDir,
-		InstanceIdFilename: "instance-id",
-	}, testLogger())
-
-	instanceId, isFallback, err := reader.GetInstanceId()
-	require.NoError(t, err)
-	assert.Equal(t, "inst-from-file", instanceId)
-	assert.False(t, isFallback)
-}
-
-func TestGetInstanceId_IMDSFallback(t *testing.T) {
+func TestGetInstanceId_FromIMDS(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == instanceDataPath {
 			_, err := w.Write([]byte(`{"id": "inst-from-imds", "parent_id": "parent-456"}`))
@@ -75,18 +61,41 @@ func TestGetInstanceId_IMDSFallback(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// No file exists — falls back to IMDS
+	tmpDir := t.TempDir()
+	err := os.WriteFile(filepath.Join(tmpDir, "instance-id"), []byte("inst-from-file\n"), 0644)
+	require.NoError(t, err)
+
 	reader := NewReader(Config{
 		UseMetadataService:         true,
 		MetadataServiceURL:         server.URL,
 		MetadataServiceFallbackURL: server.URL,
-		Path:                       t.TempDir(),
+		Path:                       tmpDir,
+		InstanceIdFilename:         "instance-id",
+	}, testLogger())
+
+	// IMDS is primary when UseMetadataService is true; the file must not be touched.
+	instanceId, isFallback, err := reader.GetInstanceId()
+	require.NoError(t, err)
+	assert.Equal(t, "inst-from-imds", instanceId)
+	assert.False(t, isFallback)
+}
+
+func TestGetInstanceId_FileFallback_WhenIMDSFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	err := os.WriteFile(filepath.Join(tmpDir, "instance-id"), []byte("inst-from-file\n"), 0644)
+	require.NoError(t, err)
+
+	reader := NewReader(Config{
+		UseMetadataService:         true,
+		MetadataServiceURL:         "http://127.0.0.1:1",
+		MetadataServiceFallbackURL: "http://127.0.0.1:1",
+		Path:                       tmpDir,
 		InstanceIdFilename:         "instance-id",
 	}, testLogger())
 
 	instanceId, isFallback, err := reader.GetInstanceId()
 	require.NoError(t, err)
-	assert.Equal(t, "inst-from-imds", instanceId)
+	assert.Equal(t, "inst-from-file", instanceId)
 	assert.True(t, isFallback)
 }
 
@@ -101,10 +110,10 @@ func TestGetInstanceId_IMDSFallbackURL(t *testing.T) {
 	}))
 	defer fallbackServer.Close()
 
-	// No file exists, primary IMDS unreachable — falls back to IMDS fallback URL
+	// Primary IMDS unreachable — uses fallback URL; still treated as IMDS, not a file fallback.
 	reader := NewReader(Config{
 		UseMetadataService:         true,
-		MetadataServiceURL:         "http://127.0.0.1:1", // unreachable
+		MetadataServiceURL:         "http://127.0.0.1:1",
 		MetadataServiceFallbackURL: fallbackServer.URL,
 		Path:                       t.TempDir(),
 		InstanceIdFilename:         "instance-id",
@@ -113,7 +122,7 @@ func TestGetInstanceId_IMDSFallbackURL(t *testing.T) {
 	instanceId, isFallback, err := reader.GetInstanceId()
 	require.NoError(t, err)
 	assert.Equal(t, "inst-fallback", instanceId)
-	assert.True(t, isFallback)
+	assert.False(t, isFallback)
 }
 
 func TestGetIamToken_IMDS(t *testing.T) {
@@ -475,4 +484,66 @@ func TestIMDS_ServerError(t *testing.T) {
 	parentId, err := reader.GetParentId()
 	require.NoError(t, err)
 	assert.Equal(t, "parent-from-file", parentId)
+}
+
+// makeHangingFile returns a path to a FIFO that blocks os.ReadFile in open(2)
+// until a writer appears, which never happens in these tests — simulating a
+// hung mount.
+func makeHangingFile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "hang")
+	require.NoError(t, syscall.Mkfifo(path, 0600))
+	return path
+}
+
+func TestReadAndTrimFile_TimesOutOnHungFile(t *testing.T) {
+	prev := fileReadTimeout
+	fileReadTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { fileReadTimeout = prev })
+
+	reader := NewReader(Config{}, testLogger())
+
+	start := time.Now()
+	_, err := reader.readAndTrimFile(makeHangingFile(t))
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout reading")
+	assert.Less(t, elapsed, time.Second, "should return shortly after timeout, not block")
+}
+
+func TestReadAndTrimFile_PanicsWhenLeakCapExceeded(t *testing.T) {
+	prev := fileReadTimeout
+	fileReadTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { fileReadTimeout = prev })
+
+	reader := NewReader(Config{}, testLogger())
+	hang := makeHangingFile(t)
+
+	// Saturate the cap by leaking maxPendingFileReads goroutines in parallel.
+	var wg sync.WaitGroup
+	var done atomic.Int64
+	for i := 0; i < maxPendingFileReads; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = reader.readAndTrimFile(hang)
+			done.Add(1)
+		}()
+	}
+	// Wait until all callers returned from their timeout select — the FIFO
+	// open never completes, so each one leaves a goroutine stuck on open(2).
+	require.Eventually(t, func() bool {
+		return done.Load() == int64(maxPendingFileReads)
+	}, 3*time.Second, 10*time.Millisecond)
+	wg.Wait()
+	require.EqualValues(t, maxPendingFileReads, reader.pendingFileReads.Load(),
+		"all read goroutines should still be in flight")
+
+	// The next call trips the cap and panics.
+	require.PanicsWithValue(t,
+		fmt.Sprintf("metadata: %d leaked file-read goroutines exceed cap %d (filename=%s)",
+			maxPendingFileReads+1, maxPendingFileReads, hang),
+		func() { _, _ = reader.readAndTrimFile(hang) },
+	)
 }

--- a/tests/integration/integration_suite.go
+++ b/tests/integration/integration_suite.go
@@ -24,6 +24,11 @@ import (
 const (
 	mockServerControlURL = "http://localhost:18080"
 	updaterContainerName = "updater-test"
+
+	cmdSystemctl = "systemctl"
+	flagNoPager  = "--no-pager"
+
+	removeFlagA = "REMOVE_FLAG_A"
 )
 
 type UpdaterSuite struct {
@@ -221,7 +226,7 @@ func (s *UpdaterSuite) waitForSystemdReady() error {
 
 	for i := 0; i < 60; i++ {
 		execConfig := container.ExecOptions{
-			Cmd:          []string{"systemctl", "is-system-running"},
+			Cmd:          []string{cmdSystemctl, "is-system-running"},
 			AttachStdout: true,
 			AttachStderr: true,
 		}
@@ -258,7 +263,7 @@ func (s *UpdaterSuite) checkServiceActive(serviceName string) error {
 	ctx := context.Background()
 	for i := 0; i < 30; i++ {
 		execConfig := container.ExecOptions{
-			Cmd:          []string{"systemctl", "is-active", serviceName},
+			Cmd:          []string{cmdSystemctl, "is-active", serviceName},
 			AttachStdout: true,
 			AttachStderr: true,
 		}
@@ -318,7 +323,7 @@ update_repo_script_path: /usr/local/bin/fake-update-repo.sh
 
 func (s *UpdaterSuite) startUpdater() {
 	cmd := exec.CommandContext(context.Background(), "docker", "exec", s.containerID,
-		"systemctl", "restart", "nebius_observability_agent_updater")
+		cmdSystemctl, "restart", "nebius_observability_agent_updater")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		s.T().Logf("systemctl restart output: %s", string(output))
@@ -556,16 +561,16 @@ func (s *UpdaterSuite) printContainerLogs(message string) {
 
 	// Updater journal logs
 	s.T().Logf("\n--- Updater Journal Logs ---")
-	s.logContainerExecOutput(ctx, []string{"journalctl", "-u", "nebius_observability_agent_updater", "-n", "200", "--no-pager"})
+	s.logContainerExecOutput(ctx, []string{"journalctl", "-u", "nebius_observability_agent_updater", "-n", "200", flagNoPager})
 
 	// Fake agent journal logs
 	s.T().Logf("\n--- Fake Agent Journal Logs ---")
-	s.logContainerExecOutput(ctx, []string{"journalctl", "-u", "nebius_observability_agent", "-n", "50", "--no-pager"})
+	s.logContainerExecOutput(ctx, []string{"journalctl", "-u", "nebius_observability_agent", "-n", "50", flagNoPager})
 
 	// Systemd service statuses
 	s.T().Logf("\n--- Systemd Status ---")
-	s.logContainerExecOutput(ctx, []string{"systemctl", "status", "nebius_observability_agent_updater", "--no-pager"})
-	s.logContainerExecOutput(ctx, []string{"systemctl", "status", "nebius_observability_agent", "--no-pager"})
+	s.logContainerExecOutput(ctx, []string{cmdSystemctl, "status", "nebius_observability_agent_updater", flagNoPager})
+	s.logContainerExecOutput(ctx, []string{cmdSystemctl, "status", "nebius_observability_agent", flagNoPager})
 
 	s.T().Logf("\n=== End of logs ===")
 }

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -180,7 +180,7 @@ func (s *UpdaterSuite) TestFeatureFlagRemoval() {
 	s.setMockResponse(&agentmanager.GetVersionResponse{
 		Action: agentmanager.Action_NOP,
 		FeatureFlags: map[string]string{
-			"REMOVE_FLAG_A": "1",
+			removeFlagA:     "1",
 			"REMOVE_FLAG_B": "2",
 		},
 	})
@@ -200,7 +200,7 @@ func (s *UpdaterSuite) TestFeatureFlagRemoval() {
 	s.setMockResponse(&agentmanager.GetVersionResponse{
 		Action: agentmanager.Action_RESTART,
 		FeatureFlags: map[string]string{
-			"REMOVE_FLAG_A": "1",
+			removeFlagA: "1",
 		},
 	})
 
@@ -219,7 +219,7 @@ func (s *UpdaterSuite) TestFeatureFlagRemoval() {
 	s.setMockResponse(&agentmanager.GetVersionResponse{
 		Action: agentmanager.Action_NOP,
 		FeatureFlags: map[string]string{
-			"REMOVE_FLAG_A": "1",
+			removeFlagA: "1",
 		},
 	})
 }


### PR DESCRIPTION
GetInstanceId now prefers IMDS when use_metadata_service is enabled and only falls back to the file on IMDS error, so a wedged metadata mount no longer blocks every poll. readAndTrimFile runs os.ReadFile in a bounded goroutine with a 5s timeout; if leaked read goroutines exceed 100 the process panics so systemd restarts it on a recovered mount.